### PR TITLE
Implement FX scoring service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+events.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# weekly-quest.yml

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,27 @@
+{
+  "currencies": ["USD","EUR","CHF","JPY","NZD","AUD","CAD","GBP"],
+  "indicators": [
+    {
+      "id": "us_fomc_rate_decision",
+      "name": "FOMC Rate Decision",
+      "ccy": "USD",
+      "impact": "high",
+      "freq": "8x/year",
+      "fields": ["actual","consensus","prior","statement","press_conf"],
+      "dir_rule": "hawkish_is_bullish",
+      "typical_release_utc": "18:00-20:00",
+      "notes": "Use decision + statement + dot_plot if SEP"
+    },
+    {
+      "id": "us_cpi_core_yoy",
+      "name": "CPI Core YoY",
+      "ccy": "USD",
+      "impact": "high",
+      "freq": "monthly",
+      "fields": ["actual","consensus","prior"],
+      "dir_rule": "higher_is_bullish",
+      "typical_release_utc": "12:30",
+      "transform": "surprise = actual - consensus"
+    }
+  ]
+}

--- a/event_store.py
+++ b/event_store.py
@@ -1,0 +1,97 @@
+"""Revision-aware event storage for economic releases.
+
+Each event is stored with its vintage (flash/prelim/final) so that
+revisions never overwrite prior releases.  Only events with
+``release_time_utc`` in the past can be retrieved for scoring.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+
+@dataclass
+class Event:
+    series_id: str
+    release_date: str  # YYYY-MM-DD
+    vintage: str       # flash/prelim/final
+    actual: float
+    consensus: Optional[float]
+    previous: Optional[float]
+    impact: str
+    release_time_utc: str  # ISO timestamp
+    provider: str
+
+
+class EventStore:
+    """SQLite backed store tracking event revisions."""
+
+    def __init__(self, path: str = "events.db") -> None:
+        self.conn = sqlite3.connect(path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS events (
+                series_id TEXT,
+                release_date TEXT,
+                vintage TEXT,
+                actual REAL,
+                consensus REAL,
+                previous REAL,
+                impact TEXT,
+                release_time_utc TEXT,
+                provider TEXT,
+                PRIMARY KEY(series_id, release_date, vintage)
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add_event(self, event: Event) -> None:
+        """Insert a new event if its release time is not in the future."""
+        rt = datetime.fromisoformat(event.release_time_utc)
+        if rt > datetime.now(timezone.utc):
+            raise ValueError("release_time_utc is in the future")
+        self.conn.execute(
+            """
+            INSERT OR REPLACE INTO events
+            (series_id, release_date, vintage, actual, consensus, previous,
+             impact, release_time_utc, provider)
+            VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                event.series_id,
+                event.release_date,
+                event.vintage,
+                event.actual,
+                event.consensus,
+                event.previous,
+                event.impact,
+                event.release_time_utc,
+                event.provider,
+            ),
+        )
+        self.conn.commit()
+
+    def fetch_events(
+        self, series_id: str, as_of: Optional[datetime] = None
+    ) -> Iterable[Event]:
+        """Yield events for ``series_id`` with release_time_utc <= ``as_of``."""
+        if as_of is None:
+            as_of = datetime.now(timezone.utc)
+        cur = self.conn.execute(
+            """
+            SELECT series_id, release_date, vintage, actual, consensus, previous,
+                   impact, release_time_utc, provider
+            FROM events
+            WHERE series_id = ? AND release_time_utc <= ?
+            ORDER BY release_date ASC, vintage ASC
+            """,
+            (series_id, as_of.isoformat()),
+        )
+        for row in cur.fetchall():
+            yield Event(*row)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,42 @@
+"""Example workflow fetching data, storing events and computing scores."""
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from event_store import Event, EventStore
+from normalizer import normalize_units
+from providers import FredProvider, ProviderRegistry, WorldBankProvider
+from scoring import category_score
+
+
+SERIES_ID = "US_CPI"
+
+
+def run() -> None:
+    registry = ProviderRegistry()
+    wb_map = {SERIES_ID: ("USA", "FP.CPI.TOTL.ZG")}
+    fred_map = {SERIES_ID: "CPIAUCSL"}
+    registry.register(SERIES_ID, [FredProvider(fred_map), WorldBankProvider(wb_map)])
+    store = EventStore()
+
+    payload = normalize_units(asdict(registry.fetch(SERIES_ID)))
+    event = Event(
+        series_id=SERIES_ID,
+        release_date=payload["release_time_utc"][:10],
+        vintage="final",
+        actual=payload["actual"],
+        consensus=payload["consensus"],
+        previous=payload["previous"],
+        impact=payload["impact"],
+        release_time_utc=payload["release_time_utc"],
+        provider=payload["provider"],
+    )
+    store.add_event(event)
+
+    events = list(store.fetch_events(SERIES_ID))
+    score = category_score([(ev, "q") for ev in events])
+    print(f"Score for {SERIES_ID}: {score:.2f}")
+
+
+if __name__ == "__main__":
+    run()

--- a/normalizer.py
+++ b/normalizer.py
@@ -1,0 +1,28 @@
+"""Utilities to normalize raw event payloads."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Dict, Optional
+
+from dateutil import parser, tz
+
+
+def normalize_units(payload: Dict) -> Dict:
+    """Normalize units such as percentages to ratios."""
+
+    unit = payload.get("unit", "").lower()
+    if unit in {"%", "percent", "percentage"}:
+        for key in ["actual", "consensus", "previous"]:
+            if payload.get(key) is not None:
+                payload[key] = float(payload[key]) / 100.0
+        payload["unit"] = "ratio"
+    return payload
+
+
+def to_utc(local_ts: str, source_tz: Optional[str] = None) -> str:
+    """Convert a timestamp in ``source_tz`` to UTC (DST safe)."""
+
+    dt = parser.isoparse(local_ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=tz.gettz(source_tz or "UTC"))
+    return dt.astimezone(tz.UTC).isoformat().replace("+00:00", "Z")

--- a/providers.py
+++ b/providers.py
@@ -1,0 +1,119 @@
+"""Provider registry supporting primary and fallback data sources.
+
+The module provides small provider implementations for the World Bank and
+FRED APIs.  Both expose a ``fetch`` method returning :class:`EventPayload` and
+can be combined via :class:`ProviderRegistry` to create multi-source consensus
+logic.  No Trading Economics usage per specs.
+"""
+from __future__ import annotations
+
+import os
+import statistics
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import requests
+
+
+@dataclass
+class EventPayload:
+    series_id: str
+    actual: float
+    consensus: Optional[float]
+    previous: Optional[float]
+    impact: str
+    release_time_local: str  # local timestamp in source tz
+    release_time_utc: str    # converted to UTC
+    provider: str
+    unit: str = ""
+
+
+class WorldBankProvider:
+    """Fetches indicator values from the World Bank API."""
+
+    BASE_URL = (
+        "https://api.worldbank.org/v2/country/{country}/indicator/{indicator}?format=json"
+    )
+
+    def __init__(self, mapping: Dict[str, Tuple[str, str]]):
+        self.mapping = mapping
+
+    def fetch(self, series_id: str) -> EventPayload:
+        country, indicator = self.mapping[series_id]
+        resp = requests.get(self.BASE_URL.format(country=country, indicator=indicator))
+        resp.raise_for_status()
+        payload = resp.json()[1]
+        data = payload[0]
+        value = float(data["value"])
+        date = f"{data['date']}-12-31"  # annual data at year end
+        previous = float(payload[1]["value"]) if len(payload) > 1 else None
+        consensus = previous  # naive nowcast
+        return EventPayload(
+            series_id=series_id,
+            actual=value,
+            consensus=consensus,
+            previous=previous,
+            impact="mid",
+            release_time_local=f"{date}T00:00:00",
+            release_time_utc=f"{date}T00:00:00Z",
+            provider="worldbank",
+            unit="percent",
+        )
+
+
+class FredProvider:
+    """Fetches data from the FRED API (https://fred.stlouisfed.org)."""
+
+    BASE_URL = "https://api.stlouisfed.org/fred/series/observations"
+
+    def __init__(self, mapping: Dict[str, str], api_key: Optional[str] = None):
+        self.mapping = mapping
+        self.api_key = api_key or os.getenv("FRED_API_KEY")
+
+    def fetch(self, series_id: str) -> EventPayload:
+        if not self.api_key:
+            raise RuntimeError("FRED API key missing")
+        fred_id = self.mapping[series_id]
+        params = {
+            "series_id": fred_id,
+            "api_key": self.api_key,
+            "file_type": "json",
+            "sort_order": "desc",
+            "limit": 2,
+        }
+        resp = requests.get(self.BASE_URL, params=params)
+        resp.raise_for_status()
+        data = resp.json()["observations"]
+        latest, prev = data[0], data[1] if len(data) > 1 else ({"value": None, "date": None})
+        value = float(latest["value"])
+        previous = float(prev["value"]) if prev["value"] not in (None, ".") else None
+        date = latest["date"]
+        return EventPayload(
+            series_id=series_id,
+            actual=value,
+            consensus=previous,  # proxy consensus
+            previous=previous,
+            impact="mid",
+            release_time_local=f"{date}T00:00:00",
+            release_time_utc=f"{date}T00:00:00Z",
+            provider="fred",
+            unit="index",
+        )
+
+
+class ProviderRegistry:
+    """Registry mapping series IDs to a list of providers (primary first)."""
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, List[object]] = {}
+
+    def register(self, series_id: str, providers: List[object]) -> None:
+        self._providers[series_id] = providers
+
+    def fetch(self, series_id: str) -> EventPayload:
+        for provider in self._providers.get(series_id, []):
+            try:
+                return provider.fetch(series_id)
+            except Exception:
+                continue
+        raise RuntimeError(f"no provider could fetch series {series_id}")

--- a/scoring.py
+++ b/scoring.py
@@ -1,0 +1,73 @@
+"""Scoring utilities turning events into pillar/column points."""
+from __future__ import annotations
+
+import math
+import statistics
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Tuple
+
+from event_store import Event, EventStore
+
+IMPACT_WEIGHT = {"high": 3.0, "mid": 1.5, "low": 0.75}
+HALF_LIFE = {"w": 14, "m": 45, "q": 90, "policy": 90}
+
+
+def surprise(event: Event, direction: str) -> float:
+    if event.consensus is None:
+        return 0.0
+    if direction == "relative":
+        return (event.actual / event.consensus) - 1
+    return event.actual - event.consensus
+
+
+def z_score(series_id: str, surprises: List[float]) -> float:
+    if not surprises:
+        return 0.0
+    mu = statistics.mean(surprises)
+    sigma = statistics.pstdev(surprises) or 1.0
+    return (surprises[-1] - mu) / sigma
+
+
+def decay_weight(release_time: str, freq: str, impact: str) -> float:
+    rt = datetime.fromisoformat(release_time)
+    days = (datetime.now(timezone.utc) - rt).days
+    hl = HALF_LIFE.get(freq, 30)
+    decay = 0.5 ** (days / hl)
+    return decay * IMPACT_WEIGHT.get(impact, 1.0)
+
+
+def point_from_z(z: float) -> float:
+    if abs(z) < 0.25:
+        return 0.0
+    return max(-2.0, min(2.0, 2 * math.tanh(z / 1.5)))
+
+
+def category_score(events: Iterable[Tuple[Event, str]]) -> float:
+    surprises = []
+    weights = []
+    for ev, freq in events:
+        s = surprise(ev, "relative") if "%" in str(ev.actual) else surprise(ev, "absolute")
+        z = z_score(ev.series_id, surprises + [s])
+        w = decay_weight(ev.release_time_utc, freq, ev.impact)
+        surprises.append(s)
+        weights.append(z * w)
+    if not weights:
+        return 0.0
+    z_cat = sum(weights) / len(weights)
+    return point_from_z(z_cat)
+
+
+def pair_point(base: float, quote: float) -> int:
+    if base > 0 and quote < 0:
+        return 2
+    if base < 0 and quote > 0:
+        return -2
+    if base > 0 and quote == 0:
+        return 1
+    if base < 0 and quote == 0:
+        return -1
+    if base == 0 and quote < 0:
+        return 1
+    if base == 0 and quote > 0:
+        return -1
+    return 0


### PR DESCRIPTION
## Summary
- add SQLite-backed event store preserving indicator vintages
- introduce provider registry with WorldBank and FRED API support
- compute category scores and pair logic with reusable scoring helpers

## Testing
- `pip install requests python-dateutil`
- `python -m py_compile event_store.py providers.py normalizer.py scoring.py main.py`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab9d60bbcc83269768fbd01dd918a8